### PR TITLE
Fix for DjangoCMS 3.5: Use cms.utils.conf for get_cms_setting

### DIFF
--- a/djangocms_page_sitemap/cms_toolbars.py
+++ b/djangocms_page_sitemap/cms_toolbars.py
@@ -6,7 +6,7 @@ from cms.cms_toolbars import PAGE_MENU_THIRD_BREAK
 from cms.toolbar.items import Break
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
-from cms.utils import get_cms_setting
+from cms.utils.conf import get_cms_setting
 from django.core.urlresolvers import NoReverseMatch, reverse
 from django.utils.translation import ugettext_lazy as _
 

--- a/djangocms_page_sitemap/settings.py
+++ b/djangocms_page_sitemap/settings.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from cms.sitemaps import CMSSitemap
-from cms.utils import get_cms_setting
+from cms.utils.conf import get_cms_setting
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 


### PR DESCRIPTION
ImportError: cannot import name get_cms_setting