### PR TITLE
Apply workaround to avoid triggering Page.site_id deprecation warning

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 0.5.2 (unreleased)
 ++++++++++++++++++
 
-* placeholder
+* Apply workaround to avoid triggering ``Page.site_id`` deprecation warning
 
 0.5.2 (2018-04-07)
 ++++++++++++++++++

--- a/djangocms_page_sitemap/utils.py
+++ b/djangocms_page_sitemap/utils.py
@@ -8,5 +8,8 @@ def get_cache_key(page):
     """
     Create the cache key for the current page and language
     """
-    site_id = page.site_id
+    try:
+        site_id = page.node.site_id
+    except AttributeError:
+        site_id = page.site_id
     return _get_cache_key('page_sitemap', page, 'default', site_id)


### PR DESCRIPTION
Fix #28 