### PR TITLE
Compatibility with Django-CMS 3.7.2

### DIFF
--- a/djangocms_page_sitemap/models.py
+++ b/djangocms_page_sitemap/models.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from cms.extensions import PageExtension, extension_pool
 from cms.models import Page
-from django.utils.six import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.core.cache import cache
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models

--- a/djangocms_page_sitemap/models.py
+++ b/djangocms_page_sitemap/models.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from cms.extensions import PageExtension, extension_pool
 from cms.models import Page
-from cms.utils.compat.dj import python_2_unicode_compatible
+from django.utils.six import python_2_unicode_compatible
 from django.core.cache import cache
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models


### PR DESCRIPTION
python_2_unicode_compatible is no more defined in cms.utils.compat.dj

See https://forum.djangoproject.com/t/python-2-unicode-compatible/715