### PR TITLE
Temporarely pin tests to django CMS 3.7.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     cms36: https://github.com/divio/django-cms/archive/release/3.6.x.zip
-    cms37: https://github.com/divio/django-cms/archive/release/3.7.x.zip
+    cms37: django-cms==3.7.1
     cmsdev: https://github.com/divio/django-cms/archive/develop.zip
     -r{toxinidir}/requirements-test.txt
 


### PR DESCRIPTION
django CMS 3.7.2 support will be added back by #52 