### PR TITLE
Updated lastmod() to return latest publish version modified date in cms4

### DIFF
--- a/djangocms_page_sitemap/sitemap.py
+++ b/djangocms_page_sitemap/sitemap.py
@@ -82,8 +82,8 @@ class ExtendedSitemap(CMSSitemap):
                 return self.default_changefreq
 
     def lastmod(self, page_url):
-        # if versionining is enabledcode below is Added to return the latest version modified
-        # date of the page. if versioning is disabled lastmod() returns the page changed_date
+        # if versioning is enabled we  return the latest version modified using the versioning
+        # modified date. if versioning is disabled we return the page changed_date
         if is_versioning_enabled():
             site = get_current_site()
             page_contents = PageContent.objects.filter(

--- a/djangocms_page_sitemap/sitemap.py
+++ b/djangocms_page_sitemap/sitemap.py
@@ -83,7 +83,7 @@ class ExtendedSitemap(CMSSitemap):
 
     def lastmod(self, page_url):
         # if versionining is enabledcode below is Added to return the latest version modified
-        # date of the page. if versionining is disabled lastmod() returns the changed_date from page
+        # date of the page. if versioning is disabled lastmod() returns the page changed_date
         if is_versioning_enabled():
             site = get_current_site()
             page_contents = PageContent.objects.filter(

--- a/djangocms_page_sitemap/utils.py
+++ b/djangocms_page_sitemap/utils.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-from django.apps import apps
-
 from cms.cache import _get_cache_key
+from django.apps import apps
 
 
 def get_cache_key(page):

--- a/djangocms_page_sitemap/utils.py
+++ b/djangocms_page_sitemap/utils.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
+from django.apps import apps
+
 from cms.cache import _get_cache_key
 
 
@@ -13,3 +15,12 @@ def get_cache_key(page):
     except AttributeError:
         site_id = page.site_id
     return _get_cache_key('page_sitemap', page, 'default', site_id)
+
+
+def is_versioning_enabled():
+    from cms.models import PageContent
+    try:
+        app_config = apps.get_app_config('djangocms_versioning')
+        return app_config.cms_extension.is_content_model_versioned(PageContent)
+    except LookupError:
+        return False

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ coveralls
 flake8>=2.1.0
 tox>=2.0
 django-app-helper
+http://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning-0.0.28

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,4 +3,3 @@ coveralls
 flake8>=2.1.0
 tox>=2.0
 django-app-helper
-http://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning-0.0.28

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -71,7 +71,7 @@ class SitemapTest(BaseTest):
         page3.delete()
         self.assertEqual(cache.get(ext_key), None)
 
-    @skipIf(not is_versioning_enabled(), 'Right now this feature wont work without versioning')
+    @skipIf(not is_versioning_enabled(), 'This test can only run when versioning is installed')
     def test_pageurl_lastmod_with_cms4_versioning(self):
         # Check the latest version modified date for the page is checked for lastmod()
         # if versioning is enabled, Currenly test is skipped , as this may require changes in testsuite

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from decimal import Decimal
-
 from unittest import skipIf
 
 from django.core.cache import cache


### PR DESCRIPTION
Lastmod() currently returns the page changed_date. If djangocms_versioning is installed and enabled on cms4, then lastmod key for the PageUrl in sitemap, should return the pagecontent's latest version modified  date.

1. Test has been added for the change , but at present we are skipping as this may require change in test suite to make it compatible with djangocms_versioning.