### PR TITLE
Use the correct toolbar for versioning and django-cms v4

### DIFF
--- a/djangocms_page_sitemap/cms_toolbars.py
+++ b/djangocms_page_sitemap/cms_toolbars.py
@@ -10,11 +10,14 @@ from django.utils.translation import ugettext_lazy as _
 from .models import PageSitemapProperties
 from .utils import is_versioning_enabled
 
+# Handle versioned toolbar if it exists, otherwise just use the normal CMS toolbar
+from cms.cms_toolbars import PageToolbar
 if is_versioning_enabled:
     try:
         from djangocms_versioning.cms_toolbars import VersioningPageToolbar as PageToolbar
     except ImportError:
-        from cms.cms_toolbars import PageToolbar
+        pass
+
 
 PAGE_SITEMAP_MENU_TITLE = _('Sitemap properties')
 

--- a/djangocms_page_sitemap/cms_toolbars.py
+++ b/djangocms_page_sitemap/cms_toolbars.py
@@ -8,15 +8,12 @@ from django.urls import NoReverseMatch, reverse
 from django.utils.translation import ugettext_lazy as _
 
 from .models import PageSitemapProperties
-from .utils import is_versioning_enabled
 
 # Handle versioned toolbar if it exists, otherwise just use the normal CMS toolbar
-from cms.cms_toolbars import PageToolbar
-if is_versioning_enabled:
-    try:
-        from djangocms_versioning.cms_toolbars import VersioningPageToolbar as PageToolbar
-    except ImportError:
-        pass
+try:
+    from djangocms_versioning.cms_toolbars import VersioningPageToolbar as PageToolbar
+except ImportError:
+    from cms.cms_toolbars import PageToolbar
 
 
 PAGE_SITEMAP_MENU_TITLE = _('Sitemap properties')

--- a/djangocms_page_sitemap/cms_toolbars.py
+++ b/djangocms_page_sitemap/cms_toolbars.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-from cms.cms_toolbars import PlaceholderToolbar
+from cms.cms_toolbars import PageToolbar
 from cms.toolbar_pool import toolbar_pool
 from cms.utils.conf import get_cms_setting
 from cms.utils.permissions import has_page_permission
@@ -9,12 +9,19 @@ from django.urls import NoReverseMatch, reverse
 from django.utils.translation import ugettext_lazy as _
 
 from .models import PageSitemapProperties
+from .utils import is_versioning_enabled
+
+if is_versioning_enabled:
+    try:
+        from djangocms_versioning.cms_toolbars import VersioningPageToolbar as PageToolbar
+    except ImportError:
+        pass
 
 PAGE_SITEMAP_MENU_TITLE = _('Sitemap properties')
 
 
 @toolbar_pool.register
-class PageSitemapPropertiesMeta(PlaceholderToolbar):
+class PageSitemapPropertiesMeta(PageToolbar):
     def populate(self):
         self.page = self.request.current_page
         if not self.page:
@@ -34,11 +41,7 @@ class PageSitemapPropertiesMeta(PlaceholderToolbar):
             self.request.current_page.has_change_permission(self.request.user)
         )
         if has_global_current_page_change_permission or can_change:
-            try:
-                # cms 3.4.5 compat
-                not_edit_mode = not self.toolbar.edit_mode
-            except AttributeError:
-                not_edit_mode = not self.toolbar.edit_mode_active
+            not_edit_mode = not self.toolbar.edit_mode_active
             current_page_menu = self.toolbar.get_or_create_menu('page')
             # Page tags
             try:

--- a/djangocms_page_sitemap/cms_toolbars.py
+++ b/djangocms_page_sitemap/cms_toolbars.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-from cms.cms_toolbars import PageToolbar
 from cms.toolbar_pool import toolbar_pool
 from cms.utils.conf import get_cms_setting
 from cms.utils.permissions import has_page_permission
@@ -15,7 +14,7 @@ if is_versioning_enabled:
     try:
         from djangocms_versioning.cms_toolbars import VersioningPageToolbar as PageToolbar
     except ImportError:
-        pass
+        from cms.cms_toolbars import PageToolbar
 
 PAGE_SITEMAP_MENU_TITLE = _('Sitemap properties')
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -29,12 +29,12 @@ class BaseTest(TestCase):
 
     def get_pages(self):
         from cms.api import create_page, create_title
-        page_1 = create_page('page one', 'page.html', language='en')
-        page_2 = create_page('page two', 'page.html', language='en')
-        page_3 = create_page('page three', 'page.html', language='en')
-        create_title(language='fr', title='page un', page=page_1)
-        create_title(language='it', title='pagina uno', page=page_1)
-        create_title(language='fr', title='page trois', page=page_3)
+        page_1 = create_page('page one', 'page.html', language='en', created_by=self.user)
+        page_2 = create_page('page two', 'page.html', language='en', created_by=self.user)
+        page_3 = create_page('page three', 'page.html', language='en', created_by=self.user)
+        create_title(language='fr', title='page un', page=page_1, created_by=self.user)
+        create_title(language='it', title='pagina uno', page=page_1, created_by=self.user)
+        create_title(language='fr', title='page trois', page=page_3, created_by=self.user)
         if hasattr(page_1, 'set_as_homepage'):
             page_1.set_as_homepage()
 

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -79,7 +79,7 @@ class SitemapTest(BaseTest):
         page_1 = create_page('page-one', 'page.html', language='en', created_by=self.user)
         page_content = create_title(title='page un', language='en', page=page_1, created_by=self.user)
         last_modified_date = '<lastmod>%s</lastmod>' % (
-            page_content.get.versions.first().modified.strftime('%Y-%m-%d')
+            page_content.versions.first().modified.strftime('%Y-%m-%d')
         )
         expected_string = '<url><loc>http://example.com%s</loc>%s<changefreq>monthly</changefreq><priority>0.5</priority></url>' % (page_1.get_absolute_url(language='en'), last_modified_date)
         sitemap = self.client.get('/sitemap.xml')

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -148,7 +148,7 @@ class VersioningToolbarTest(CMSTestCase):
         """
         user = self.get_superuser()
         page_1 = create_page('page-one', 'page.html', language='en', created_by=user)
-        page_content = create_title(title='page un', language='en', page=page_1, created_by=user)
+        page_content = page_1.get_title_obj(language='en')
         preview_endpoint = get_object_preview_url(page_content, language='en')
 
         with self.login_user_context(self.get_superuser()):

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -1,16 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
+from cms.api import create_page
+from cms.test_utils.testcases import CMSTestCase
+from cms.toolbar.items import Menu, ModalItem
+from cms.toolbar.utils import get_object_preview_url
 from django.contrib.auth.models import Permission, User
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
-
-from cms.api import create_page, create_title
-from cms.toolbar.items import Menu, ModalItem
-from cms.toolbar.utils import get_object_preview_url
-from cms.test_utils.testcases import CMSTestCase
 
 from djangocms_page_sitemap.cms_toolbars import PAGE_SITEMAP_MENU_TITLE
 from djangocms_page_sitemap.models import PageSitemapProperties

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -154,8 +154,8 @@ class VersioningToolbarTest(CMSTestCase):
         with self.login_user_context(self.get_superuser()):
             response = self.client.post(preview_endpoint)
 
-        edit_button_list = self.find_toolbar_buttons("Edit", response.wsgi_request.toolbar)
-        create_button_list = self.find_toolbar_buttons("Create", response.wsgi_request.toolbar)
+        edit_button_list = find_toolbar_buttons("Edit", response.wsgi_request.toolbar)
+        create_button_list = find_toolbar_buttons("Create", response.wsgi_request.toolbar)
 
         # Only one edit and create button should exist
         self.assertEqual(len(edit_button_list), 1)

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -1,15 +1,20 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-from cms.toolbar.items import Menu, ModalItem
+from unittest import skipIf
+
 from django.contrib.auth.models import Permission, User
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from cms.toolbar.items import Menu, ModalItem
+from cms.test_utils.testcases import CMSTestCase
+
 from djangocms_page_sitemap.cms_toolbars import PAGE_SITEMAP_MENU_TITLE
 from djangocms_page_sitemap.models import PageSitemapProperties
+from djangocms_page_sitemap.utils import is_versioning_enabled
 
 from .base import BaseTest
 
@@ -117,3 +122,44 @@ class ToolbarTest(BaseTest):
             )[0].item
         self.assertTrue(meta_menu.url.startswith(reverse('admin:djangocms_page_sitemap_pagesitemapproperties_change', args=(page_ext.pk,))))
         self.assertEqual(force_text(page_ext), force_text(_('Sitemap values for Page %s') % page1.pk))
+
+
+@skipIf(not is_versioning_enabled(), 'This test case can only run when versioning is installed')
+class VersioningToolbarTest(CMSTestCase):
+
+    @staticmethod
+    def find_toolbar_buttons(button_name, toolbar):
+        """
+        Taken from: from djangocms_versioning.test_utils.test_helpers import find_toolbar_buttons
+
+        CAVEAT: This test helper is not currently accesible due to the fact that it would then enforce
+        versioning test packages and factory boy on this test suite.
+        """
+        found = []
+        for button_list in toolbar.get_right_items():
+            found = found + [
+                button for button in button_list.buttons if button.name == button_name
+            ]
+        return found
+
+    def test_toolbar_with_items(self):
+        """
+        The toolbar exists when versioning is installed and doesn't affect the toolbar buttons
+        """
+        from cms.api import create_page, create_title
+        from cms.toolbar.utils import get_object_preview_url
+
+        user = self.get_superuser()
+        page_1 = create_page('page-one', 'page.html', language='en', created_by=user)
+        page_content = create_title(title='page un', language='en', page=page_1, created_by=user)
+        preview_endpoint = get_object_preview_url(page_content, language='en')
+
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.post(preview_endpoint)
+
+        edit_button_list = self.find_toolbar_buttons("Edit", response.wsgi_request.toolbar)
+        create_button_list = self.find_toolbar_buttons("Create", response.wsgi_request.toolbar)
+
+        # Only one edit and create button should exist
+        self.assertEqual(len(edit_button_list), 1)
+        self.assertEqual(len(create_button_list), 1)

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ basepython =
     py37: python3.7
 
 [testenv:isort]
-commands = isort -c -rc
+commands = isort --recursive --check-only --diff {toxinidir}
 deps = isort
 skip_install = true
 basepython = python3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,38 @@
 [tox]
-envlist = docs,pep8,isort,py{35,36,37}-django{111,21,22}-cms40,py{27}-django{111}-cms40
+envlist =
+    docs
+    pep8
+    isort
+    py{35,36,37}-django{111,21}-cms40
+    py{35,36,37}-django22-cms40
+
+skip_missing_interpreters=True
 
 [testenv]
 commands = {env:COMMAND:python} setup.py test
+
 deps =
-    django111: Django>=1.11,<2.0
-    django111: django-formtools>=2.1,<2.2
-    django21: Django>=2.1,<2.2
-    django22: Django>=2.2,<2.3
-    cms40: https://github.com/divio/django-cms/archive/release/4.0.x.zip
     -r{toxinidir}/requirements-test.txt
 
+    # Django 1.11 installation requirements
+    django111: Django>=1.11,<2.0
+    django111: django-formtools>=2.1<2.2
+    django111: django-sekizai<2.0.0
+    django111: djangocms_admin_style<2.0.0
+    django111: django-classy-tags<2.0.0
+
+    # Django 2.1 installation requirements
+    django21: Django>=2.1,<2.2
+    django21: django-sekizai<2.0.0
+    django21: djangocms_admin_style<2.0.0
+    django21: django-classy-tags<2.0.0
+
+    django22: Django>=2.2,<2.3
+
+    cms40: https://github.com/divio/django-cms/archive/release/4.0.x.zip
+
+
 basepython =
-    py27: python2.7
     py35: python3.5
     py36: python3.6
     py37: python3.7


### PR DESCRIPTION
The Toolbar is fundamentally broken in V4 when versioning is installed. The placeholder toolbar is responsible for adding the Create and Edit buttons, when the Placeholder toolbar is extended a duplicate instance is created causing duplicated buttons to be created. 