### PR TITLE
 Fix error when populating the toolbar on page types 

### DIFF
--- a/changes/67.bugfix
+++ b/changes/67.bugfix
@@ -1,0 +1,1 @@
+Fix error when populating the toolbar on page types

--- a/djangocms_page_sitemap/cms_toolbars.py
+++ b/djangocms_page_sitemap/cms_toolbars.py
@@ -19,7 +19,9 @@ class PageSitemapPropertiesMeta(CMSToolbar):
         # always use draft if we have a page
         self.page = get_page_draft(self.request.current_page)
         if not self.page:
-            # Nothing to do
+            return
+        if self.page.is_page_type:
+            # we don't need this on page types
             return
 
         # check global permissions if CMS_PERMISSIONS is active

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -38,6 +38,32 @@ class ToolbarTest(BaseTest):
 
         self.assertEqual(len(page_menu), 1)
 
+    def test_page_types(self):
+        """
+        Test that page meta menu is not displayed on page types.
+        """
+        from cms.toolbar.toolbar import CMSToolbar
+
+        page1, page2, page3 = self.get_pages()
+        page1.is_page_type = True
+        page1.save()
+        self.user_staff.user_permissions.add(Permission.objects.get(codename="change_page"))
+        self.user_staff = User.objects.get(pk=self.user_staff.pk)
+        request = self.get_page_request(page1, self.user_staff, "/", edit=True)
+        toolbar = CMSToolbar(request)
+        toolbar.get_left_items()
+        page_menu = toolbar.menus["page"]
+        try:
+            self.assertEqual(
+                len(page_menu.find_items(ModalItem, name="%s..." % force_text(PAGE_SITEMAP_MENU_TITLE))),
+                0,
+            )
+        except AssertionError:
+            self.assertEqual(
+                len(page_menu.find_items(ModalItem, name="%s ..." % force_text(PAGE_SITEMAP_MENU_TITLE))),
+                0,
+            )
+
     def test_perm(self):
         """
         Test that page meta menu is present if user has Page.change_perm


### PR DESCRIPTION
# Description

Skip adding items to page toolbar on page types

## References

Fix #67 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-page-sitemap.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-page-sitemap.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
