### PR TITLE
fix: Do not double-check permissions

### DIFF
--- a/changes/123.bugfix
+++ b/changes/123.bugfix
@@ -1,0 +1,1 @@
+Do not double-check permissions

--- a/djangocms_page_sitemap/cms_toolbars.py
+++ b/djangocms_page_sitemap/cms_toolbars.py
@@ -3,7 +3,6 @@ from cms.cms_toolbars import PAGE_MENU_THIRD_BREAK
 from cms.toolbar.items import Break
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
-from cms.utils.conf import get_cms_setting
 from django.urls import NoReverseMatch, reverse
 from django.utils.translation import gettext_lazy as _
 

--- a/djangocms_page_sitemap/cms_toolbars.py
+++ b/djangocms_page_sitemap/cms_toolbars.py
@@ -23,7 +23,7 @@ class PageSitemapPropertiesMeta(CMSToolbar):
             # we don't need this on page types
             return
 
-        # check if user has page change permission (respects CMS_PERMISSIONS)
+        # check if user has page change permission (respects CMS_PERMISSION)
         can_change = self.request.current_page and self.request.current_page.has_change_permission(self.request.user)
         if can_change:
             not_edit_mode = not self.toolbar.edit_mode_active

--- a/djangocms_page_sitemap/cms_toolbars.py
+++ b/djangocms_page_sitemap/cms_toolbars.py
@@ -4,7 +4,6 @@ from cms.toolbar.items import Break
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
 from cms.utils.conf import get_cms_setting
-from cms.utils.permissions import has_page_permission
 from django.urls import NoReverseMatch, reverse
 from django.utils.translation import gettext_lazy as _
 
@@ -24,16 +23,9 @@ class PageSitemapPropertiesMeta(CMSToolbar):
             # we don't need this on page types
             return
 
-        # check global permissions if CMS_PERMISSIONS is active
-        if get_cms_setting("PERMISSION"):
-            has_global_current_page_change_permission = has_page_permission(
-                self.request.user, self.request.current_page, "change"
-            )
-        else:
-            has_global_current_page_change_permission = False
-        # check if user has page edit permission
+        # check if user has page change permission (respects CMS_PERMISSIONS)
         can_change = self.request.current_page and self.request.current_page.has_change_permission(self.request.user)
-        if has_global_current_page_change_permission or can_change:
+        if can_change:
             not_edit_mode = not self.toolbar.edit_mode_active
             current_page_menu = self.toolbar.get_or_create_menu("page")
             position = current_page_menu.find_first(Break, identifier=PAGE_MENU_THIRD_BREAK) - 1


### PR DESCRIPTION
# Description

Describe:

* cms_toolbars checked page permissions twice. Since the refactoring of CMS permissions in django CMS ~3.4 `page.has_change_permission` checks both global and user-specific permissions.
* `has_page_permission` will be deprecated, but in django CMS 3.11.7 due to an import error the function does not work. (Obviously, this also needs fixing in django CMS)


## References

Fix https://github.com/django-cms/django-cms/issues/7992

# Checklist

* [ ] I have read the [contribution guide](https://djangocms-page-sitemap.readthedocs.io/en/latest/contributing.html)
* [ ] Code lint checked via `inv lint`
* [ ] ``changes`` file included (see [docs](https://djangocms-page-sitemap.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
